### PR TITLE
Bug: When creating a new group from the main screen, the screen of loading apear

### DIFF
--- a/src/routes/ProtectedLayout.tsx
+++ b/src/routes/ProtectedLayout.tsx
@@ -1,14 +1,29 @@
 import { AuthProvider } from '@/context/AuthContext';
+import { getStatementFromDB } from '@/controllers/db/statements/getStatement';
 import { useAuthorization } from '@/controllers/hooks/useAuthorization';
+import { setStatement, statementSelector } from '@/redux/statements/statementsSlice';
 import LoadingPage from '@/view/pages/loadingPage/LoadingPage';
 import Page401 from '@/view/pages/page401/Page401';
 import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { Outlet, useNavigate, useParams } from 'react-router';
 
 export default function ProtectedLayout() {
 	const { statementId } = useParams();
+	const dispatch = useDispatch();
 	const navigate = useNavigate();
 	const { loading, error, isAuthorized } = useAuthorization(statementId);
+	const statement = useSelector(statementSelector(statementId));
+
+	useEffect(() => {
+		if (!statement) {
+			getStatementFromDB(statementId).then((statement) => {
+				if (statement) {
+					dispatch(setStatement(statement));
+				}
+			});
+		}
+	}, [statement?.statementId]);
 
 	useEffect(() => {
 		if (!isAuthorized && !loading && !error) {
@@ -23,7 +38,7 @@ export default function ProtectedLayout() {
 
 	if (error) {
 
-		return <Page401 />; //TODO: create a page for this error	
+		return <Page401 />;
 	}
 
 	return (


### PR DESCRIPTION
This issue occurs when a user initiates a group from the main screen. The loading page appears, and even if we refresh the page, the loading screen remains. The only way to access the group is by navigating to the home URL and entering through the card of the group that was created.