### PR TITLE
fixed exploit 

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -390,10 +390,32 @@ async function verifyAuthToken(req: Request, res: Response): Promise<string | nu
 }
 
 /**
- * Creates a wrapper for admin/maintenance HTTP functions with authentication.
- * Requires a valid Firebase ID token in the Authorization header.
- * @param {Function} handler - The function handler to wrap (receives uid as third argument)
- * @returns {Function} - Wrapped function with auth and error handling
+ * Checks whether a uid belongs to a system admin.
+ * Mirrors isSystemAdmin() in firestore.rules and the check in
+ * fn_deleteResearchLogs — the system-admin flag lives on usersV2/{uid}.
+ * Fails closed (returns false) on any lookup error.
+ */
+async function isSystemAdmin(uid: string): Promise<boolean> {
+	try {
+		const userDoc = await db.collection(Collections.users).doc(uid).get();
+
+		return userDoc.exists && userDoc.data()?.systemAdmin === true;
+	} catch (error) {
+		logError(error, { operation: 'httpFunction.isSystemAdmin', metadata: { uid } });
+
+		return false;
+	}
+}
+
+/**
+ * Creates a wrapper for admin/maintenance HTTP functions.
+ * Requires a valid Firebase ID token in the Authorization header AND that the
+ * authenticated user is a system admin (usersV2/{uid}.systemAdmin === true).
+ * Authentication alone is NOT sufficient — these endpoints run database-wide
+ * maintenance/migration jobs and must never be reachable by ordinary
+ * (including anonymous) users.
+ * @param {Function} handler - The function handler to wrap
+ * @returns {Function} - Wrapped function with auth, authorization and error handling
  */
 const wrapAdminHttpFunction = (
 	handler: (req: Request, res: Response) => Promise<void>,
@@ -412,6 +434,14 @@ const wrapAdminHttpFunction = (
 		async (req, res) => {
 			const uid = await verifyAuthToken(req, res);
 			if (!uid) return;
+
+			// Authentication is not enough — require system-admin authorization.
+			if (!(await isSystemAdmin(uid))) {
+				console.info(`[${getTimestamp()}] Denied admin HTTP function for non-admin uid: ${uid}`);
+				res.status(403).json({ ok: false, error: 'Forbidden: system admin required' });
+
+				return;
+			}
 
 			const startTime = Date.now();
 			const startTimestamp = getTimestamp();
@@ -919,15 +949,16 @@ exports.seedCreditRules = wrapAdminHttpFunction(async (req: Request, res: Respon
 	res.json({ seeded, message: `Seeded ${seeded} new credit rules` });
 });
 
-// HTTP endpoint for tracking daily login (called by client on app open)
-exports.trackDailyLogin = wrapAdminHttpFunction(async (req: Request, res: Response) => {
-	const { userId, sourceApp } = req.body;
-	if (!userId) {
-		res.status(400).json({ error: 'userId is required' });
+// HTTP endpoint for tracking daily login (called by client on app open).
+// This is a per-user endpoint, NOT an admin one: it only requires a valid
+// Firebase ID token and always tracks the *authenticated* user (the token uid),
+// never a userId supplied in the request body.
+exports.trackDailyLogin = wrapHttpFunction(async (req: Request, res: Response) => {
+	const uid = await verifyAuthToken(req, res);
+	if (!uid) return;
 
-		return;
-	}
-	await trackDailyLogin(userId, sourceApp || 'main');
+	const { sourceApp } = req.body ?? {};
+	await trackDailyLogin(uid, sourceApp || 'main');
 	res.json({ success: true });
 });
 

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -8,7 +8,6 @@ import { onRequest } from 'firebase-functions/v2/https';
 import { Request, Response } from 'firebase-functions/v1';
 // The Firebase Admin SDK
 import { initializeApp, getApps } from 'firebase-admin/app';
-import { getAuth } from 'firebase-admin/auth';
 import { getFirestore } from 'firebase-admin/firestore';
 
 // Import collection constants
@@ -16,6 +15,9 @@ import { Collections, functionConfig } from '@freedi/shared-types';
 
 // Structured error handling
 import { logError } from './utils/errorHandling';
+
+// HTTP auth/authorization helpers (extracted for unit testing)
+import { verifyAuthToken, requireSystemAdmin } from './utils/httpAuth';
 
 // Import function modules
 import {
@@ -367,47 +369,6 @@ const wrapMemoryIntensiveHttpFunction = (
 };
 
 /**
- * Verifies Firebase ID token from Authorization header.
- * Returns the authenticated user's UID, or sends 401 and returns null.
- */
-async function verifyAuthToken(req: Request, res: Response): Promise<string | null> {
-	const authHeader = req.headers.authorization;
-	if (!authHeader?.startsWith('Bearer ')) {
-		res.status(401).send({ error: 'Missing or invalid Authorization header' });
-
-		return null;
-	}
-	try {
-		const token = authHeader.split('Bearer ')[1];
-		const decoded = await getAuth().verifyIdToken(token);
-
-		return decoded.uid;
-	} catch {
-		res.status(401).send({ error: 'Invalid or expired token' });
-
-		return null;
-	}
-}
-
-/**
- * Checks whether a uid belongs to a system admin.
- * Mirrors isSystemAdmin() in firestore.rules and the check in
- * fn_deleteResearchLogs — the system-admin flag lives on usersV2/{uid}.
- * Fails closed (returns false) on any lookup error.
- */
-async function isSystemAdmin(uid: string): Promise<boolean> {
-	try {
-		const userDoc = await db.collection(Collections.users).doc(uid).get();
-
-		return userDoc.exists && userDoc.data()?.systemAdmin === true;
-	} catch (error) {
-		logError(error, { operation: 'httpFunction.isSystemAdmin', metadata: { uid } });
-
-		return false;
-	}
-}
-
-/**
  * Creates a wrapper for admin/maintenance HTTP functions.
  * Requires a valid Firebase ID token in the Authorization header AND that the
  * authenticated user is a system admin (usersV2/{uid}.systemAdmin === true).
@@ -432,16 +393,9 @@ const wrapAdminHttpFunction = (
 			...overrides,
 		},
 		async (req, res) => {
-			const uid = await verifyAuthToken(req, res);
-			if (!uid) return;
-
 			// Authentication is not enough — require system-admin authorization.
-			if (!(await isSystemAdmin(uid))) {
-				console.info(`[${getTimestamp()}] Denied admin HTTP function for non-admin uid: ${uid}`);
-				res.status(403).json({ ok: false, error: 'Forbidden: system admin required' });
-
-				return;
-			}
+			const uid = await requireSystemAdmin(req, res);
+			if (!uid) return;
 
 			const startTime = Date.now();
 			const startTimestamp = getTimestamp();

--- a/functions/src/utils/__tests__/httpAuth.test.ts
+++ b/functions/src/utils/__tests__/httpAuth.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import type { Request, Response } from 'firebase-functions/v1';
+
+/**
+ * Unit tests for the admin HTTP auth/authorization gate.
+ *
+ * Covers the security fix: admin/maintenance HTTP endpoints must require a
+ * system admin, not merely a valid token. The reviewer asked specifically for
+ * "403 for non-admin, 200 for admin" — `requireSystemAdmin` is the gate that
+ * decides this (returns the uid → handler runs → 200; or writes 403 → null).
+ */
+
+// Controllable mocks (the `mock` prefix lets them be referenced inside the
+// hoisted jest.mock factories).
+const mockVerifyIdToken = jest.fn<(token: string) => Promise<{ uid: string }>>();
+const mockDocGet =
+	jest.fn<() => Promise<{ exists: boolean; data: () => { systemAdmin?: boolean } | null }>>();
+
+jest.mock('firebase-admin/auth', () => ({
+	getAuth: jest.fn(() => ({ verifyIdToken: mockVerifyIdToken })),
+}));
+
+jest.mock('firebase-admin/firestore', () => ({
+	getFirestore: jest.fn(() => ({
+		collection: jest.fn(() => ({
+			doc: jest.fn(() => ({ get: mockDocGet })),
+		})),
+	})),
+}));
+
+import { verifyAuthToken, isSystemAdmin, requireSystemAdmin } from '../httpAuth';
+
+interface MockResponse {
+	statusCode?: number;
+	status: jest.Mock<(code: number) => MockResponse>;
+	send: jest.Mock<(body?: unknown) => MockResponse>;
+	json: jest.Mock<(body?: unknown) => MockResponse>;
+}
+
+function makeRes(): MockResponse {
+	const res = {
+		statusCode: undefined as number | undefined,
+	} as MockResponse;
+	res.status = jest.fn((code: number) => {
+		res.statusCode = code;
+
+		return res;
+	});
+	res.send = jest.fn(() => res);
+	res.json = jest.fn(() => res);
+
+	return res;
+}
+
+function makeReq(authorization?: string): Request {
+	return { headers: authorization ? { authorization } : {} } as unknown as Request;
+}
+
+const asRes = (res: MockResponse): Response => res as unknown as Response;
+
+beforeEach(() => {
+	jest.clearAllMocks();
+});
+
+describe('verifyAuthToken', () => {
+	it('returns 401 and null when the Authorization header is missing', async () => {
+		const res = makeRes();
+		const uid = await verifyAuthToken(makeReq(), asRes(res));
+
+		expect(uid).toBeNull();
+		expect(res.status).toHaveBeenCalledWith(401);
+		expect(mockVerifyIdToken).not.toHaveBeenCalled();
+	});
+
+	it('returns 401 and null when the header is not a Bearer token', async () => {
+		const res = makeRes();
+		const uid = await verifyAuthToken(makeReq('Basic abc'), asRes(res));
+
+		expect(uid).toBeNull();
+		expect(res.status).toHaveBeenCalledWith(401);
+	});
+
+	it('returns the uid for a valid token', async () => {
+		mockVerifyIdToken.mockResolvedValue({ uid: 'user-123' });
+		const res = makeRes();
+		const uid = await verifyAuthToken(makeReq('Bearer good-token'), asRes(res));
+
+		expect(uid).toBe('user-123');
+		expect(mockVerifyIdToken).toHaveBeenCalledWith('good-token');
+		expect(res.status).not.toHaveBeenCalled();
+	});
+
+	it('returns 401 and null when the token is invalid/expired', async () => {
+		mockVerifyIdToken.mockRejectedValue(new Error('expired'));
+		const res = makeRes();
+		const uid = await verifyAuthToken(makeReq('Bearer bad-token'), asRes(res));
+
+		expect(uid).toBeNull();
+		expect(res.status).toHaveBeenCalledWith(401);
+	});
+});
+
+describe('isSystemAdmin', () => {
+	it('returns true when usersV2/{uid}.systemAdmin === true', async () => {
+		mockDocGet.mockResolvedValue({ exists: true, data: () => ({ systemAdmin: true }) });
+
+		await expect(isSystemAdmin('admin-1')).resolves.toBe(true);
+	});
+
+	it('returns false when systemAdmin is not true', async () => {
+		mockDocGet.mockResolvedValue({ exists: true, data: () => ({ systemAdmin: false }) });
+
+		await expect(isSystemAdmin('user-1')).resolves.toBe(false);
+	});
+
+	it('returns false when the user doc does not exist', async () => {
+		mockDocGet.mockResolvedValue({ exists: false, data: () => null });
+
+		await expect(isSystemAdmin('ghost')).resolves.toBe(false);
+	});
+
+	it('fails closed (returns false) when the lookup throws', async () => {
+		mockDocGet.mockRejectedValue(new Error('firestore down'));
+
+		await expect(isSystemAdmin('user-1')).resolves.toBe(false);
+	});
+});
+
+describe('requireSystemAdmin', () => {
+	it('returns 403 and null for an authenticated non-admin', async () => {
+		mockVerifyIdToken.mockResolvedValue({ uid: 'user-1' });
+		mockDocGet.mockResolvedValue({ exists: true, data: () => ({ systemAdmin: false }) });
+		const res = makeRes();
+
+		const uid = await requireSystemAdmin(makeReq('Bearer token'), asRes(res));
+
+		expect(uid).toBeNull();
+		expect(res.status).toHaveBeenCalledWith(403);
+	});
+
+	it('returns the uid (handler proceeds → 200) for a system admin', async () => {
+		mockVerifyIdToken.mockResolvedValue({ uid: 'admin-1' });
+		mockDocGet.mockResolvedValue({ exists: true, data: () => ({ systemAdmin: true }) });
+		const res = makeRes();
+
+		const uid = await requireSystemAdmin(makeReq('Bearer token'), asRes(res));
+
+		expect(uid).toBe('admin-1');
+		expect(res.status).not.toHaveBeenCalled();
+	});
+
+	it('returns 401 and null (no admin lookup) when unauthenticated', async () => {
+		const res = makeRes();
+
+		const uid = await requireSystemAdmin(makeReq(), asRes(res));
+
+		expect(uid).toBeNull();
+		expect(res.status).toHaveBeenCalledWith(401);
+		expect(mockDocGet).not.toHaveBeenCalled();
+	});
+});

--- a/functions/src/utils/httpAuth.ts
+++ b/functions/src/utils/httpAuth.ts
@@ -1,0 +1,72 @@
+/**
+ * Authentication + authorization helpers for HTTP (onRequest) Cloud Functions.
+ *
+ * Extracted from index.ts so the security-critical gate can be unit-tested in
+ * isolation (index.ts has heavy module-load side effects that make it
+ * impractical to import from a test).
+ */
+import { Request, Response } from 'firebase-functions/v1';
+import { getAuth } from 'firebase-admin/auth';
+import { getFirestore } from 'firebase-admin/firestore';
+import { Collections } from '@freedi/shared-types';
+import { logError } from './errorHandling';
+
+/**
+ * Verifies the Firebase ID token from the Authorization header.
+ * Returns the authenticated user's UID, or sends a 401 and returns null.
+ */
+export async function verifyAuthToken(req: Request, res: Response): Promise<string | null> {
+	const authHeader = req.headers.authorization;
+	if (!authHeader?.startsWith('Bearer ')) {
+		res.status(401).send({ error: 'Missing or invalid Authorization header' });
+
+		return null;
+	}
+	try {
+		const token = authHeader.split('Bearer ')[1];
+		const decoded = await getAuth().verifyIdToken(token);
+
+		return decoded.uid;
+	} catch {
+		res.status(401).send({ error: 'Invalid or expired token' });
+
+		return null;
+	}
+}
+
+/**
+ * Checks whether a uid belongs to a system admin.
+ * Mirrors isSystemAdmin() in firestore.rules and the check in
+ * fn_deleteResearchLogs — the system-admin flag lives on usersV2/{uid}.
+ * Fails closed (returns false) on any lookup error.
+ */
+export async function isSystemAdmin(uid: string): Promise<boolean> {
+	try {
+		const userDoc = await getFirestore().collection(Collections.users).doc(uid).get();
+
+		return userDoc.exists && userDoc.data()?.systemAdmin === true;
+	} catch (error) {
+		logError(error, { operation: 'httpAuth.isSystemAdmin', metadata: { uid } });
+
+		return false;
+	}
+}
+
+/**
+ * Authentication + authorization gate for admin/maintenance HTTP endpoints.
+ * Returns the authenticated system-admin's UID, or writes the appropriate
+ * 401/403 response and returns null. Authentication alone is NOT sufficient —
+ * the caller must be a system admin (usersV2/{uid}.systemAdmin === true).
+ */
+export async function requireSystemAdmin(req: Request, res: Response): Promise<string | null> {
+	const uid = await verifyAuthToken(req, res);
+	if (!uid) return null;
+
+	if (!(await isSystemAdmin(uid))) {
+		res.status(403).json({ ok: false, error: 'Forbidden: system admin required' });
+
+		return null;
+	}
+
+	return uid;
+}


### PR DESCRIPTION
what to do:
  1. Firebase Console → Firestore → usersV2 collection.
  2. Open your user doc (document ID = your Auth UID).
  3. Add/set field systemAdmin (boolean) = true.

  That's it. Do this once so you don't lock yourself out of the maintenance endpoints after deploy. (If your     
  account already shows the "Admin" badge in the admin app, it's already set — skip it.)